### PR TITLE
Refactor language as an argument

### DIFF
--- a/src/mlx/run.py
+++ b/src/mlx/run.py
@@ -9,12 +9,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, default="efficient-speech/lite-whisper-large-v3-turbo")
     parser.add_argument("--audio-path", type=str, default="audio.wav")
+    parser.add_argument("--language", type=str, default="en")
     args = parser.parse_args()
 
     result = mlx_whisper.transcribe(
         args.audio_path, 
         path_or_hf_repo=args.model,
-        language="en",
+        language=args.language,
         temperature=0.0,
         fp16=True,
     )


### PR DESCRIPTION
In `src/mlx/run.py`, the language is hardcoded to "en". This commit refactors that to an argument which defaults to "en". This enables pure transcription rather always translation. Example, if input was Chinese audio and "zh" was given, then output text is Chinese.